### PR TITLE
feat: use resnet50 for roadtype classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dev/
 *.dat
 .idea
 .vscode
+*.skip


### PR DESCRIPTION
This PR is for the application
1. To use resnet50 to classify roads type. Currently it's using resnet18. Resnet50 seems to be more reliable
2. Add confidence scores to the predictions